### PR TITLE
Hierarchical Templates for Array Encoding

### DIFF
--- a/javascript/lib/pack.js
+++ b/javascript/lib/pack.js
@@ -25,28 +25,61 @@
 const _util = require("./_util")
 
 /**
- *  
+ *  Packs an $array of objects using the type $template
  */
-const pack_payload = async (original, template) => {
+const pack_array = async (array, template, templates) => {
+    if (array == null || array == undefined) {
+        return null;
+    }
+
+    let array = [array.length];
+    for (let index = 0; index < array.length; index++) {
+        Array.prototype.push.apply(array, await pack_template(array[index], template, templates));
+    }
+    return array;
+} 
+
+/**
+ *  Packs an array with $original's fields following the $template 
+ */
+const pack_template = async (original, template, templates) => {
     const jsonxt = require("..")
 
     const payload = []
 
     if (template && template.columns) {
         for (let rule of template.columns) {
-            const original_value = _util.get(original, rule.path)
+            const original_value = _util.get(original, rule.path);
 
-            const encoder = jsonxt.encoders[rule.encoder]
-            if (!encoder) {
-                throw new Error(`unknown encoding: ${rule.encoder}`)
+            if (rule.encoder === "array") {
+                const encodedArray = await pack_array(original_value, templates[rule.encoder_param], templates);
+
+                if (encodedArray) {
+                    Array.prototype.push.apply(payload, encodedArray);
+                } else {
+                    payload.push(rule.UNDEFINED || jsonxt.ENCODE.UNDEFINED);
+                }
+            } else {
+                const encoder = jsonxt.encoders[rule.encoder]
+                if (!encoder) {
+                    throw new Error(`unknown encoding: ${rule.encoder}`)
+                }
+
+                const encoded_value = encoder(rule, original_value)
+
+                payload.push(encoded_value)
             }
-
-            const encoded_value = encoder(rule, original_value)
-
-            payload.push(encoded_value)
         }
     }
 
+    return payload;
+}
+
+/**
+ *  Recursively creates an array payload fields and turns it into a string
+ */
+const pack_payload = async (original, template, templates) => {
+    const payload = await pack_template(original, template, templates);
     return payload.join("/").replace(/[/]*$/, "")
 }
 
@@ -87,7 +120,7 @@ const pack = async (original, templates, type, version, resolver_name, paramd) =
         upme(_util.encode(resolver_name)),
         upme(_util.encode(type)),
         upme(_util.encode(version)),
-        await pack_payload(original, template),
+        await pack_payload(original, template, templates),
     ].join(":")
 }
 

--- a/javascript/lib/pack.js
+++ b/javascript/lib/pack.js
@@ -32,11 +32,11 @@ const pack_array = async (array, template, templates) => {
         return null;
     }
 
-    let array = [array.length];
+    let packedArray = [array.length];
     for (let index = 0; index < array.length; index++) {
-        Array.prototype.push.apply(array, await pack_template(array[index], template, templates));
+        Array.prototype.push.apply(packedArray, await pack_template(array[index], template, templates));
     }
-    return array;
+    return packedArray;
 } 
 
 /**

--- a/javascript/test/unpack.js
+++ b/javascript/test/unpack.js
@@ -145,6 +145,107 @@ describe("unpack", function() {
             })
         })
     })
+
+    describe("arrays", function() {
+        const ARRAY_TEMPLATES = {
+            "data:1": {
+                "columns": [
+                    {"path": "people", "encoder": "array", "encoder_param": "person:1"},
+                ],
+                "template": {}
+            },
+            "person:1": {
+                "columns": [
+                {"path": "given", "encoder": "string"},
+                {"path": "family", "encoder": "string"},
+                {"path": "ids", "encoder": "array", "encoder_param": "identification:1"},
+                ],
+                "template": {
+                    "type": "Person"
+                }
+            },
+            "identification:1": {
+                "columns": [
+                {"path": "name", "encoder": "string"},
+                {"path": "number", "encoder": "string"}
+                ],
+                "template": {
+                    "type": "IdentificationDocument"
+                }
+            }
+        };
+
+        it("should unpack multiple arrays", async function() {
+            const packed = "JXT::data:1:2/Jane/Doe/2/MDL/23EFG3D5CC/Passport/YNW32ND/John/Doe/2/MDL/94568DDS1/Passport/2SC6223"
+            const unpacked = await jsonxt.unpack(packed, () => {
+                return ARRAY_TEMPLATES;
+            });
+
+            const got = unpacked
+            const want = {
+                "people": [{
+                    "type": "Person",
+                    "given": "Jane",
+                    "family": "Doe",
+                    "ids": [{
+                        "type": "IdentificationDocument",
+                        "name": "MDL",
+                        "number": "23EFG3D5CC"
+                    }, {
+                        "type": "IdentificationDocument",
+                        "name": "Passport",
+                        "number": "YNW32ND"
+                    }]
+                }, {
+                    "type": "Person",
+                    "given": "John",
+                    "family": "Doe", 
+                    "ids": [{
+                        "type": "IdentificationDocument",
+                        "name": "MDL",
+                        "number": "94568DDS1"
+                    }, {
+                        "type": "IdentificationDocument",
+                        "name": "Passport",
+                        "number": "2SC6223"
+                    }]
+                }]
+            };
+
+            assert.deepEqual(got, want)
+        })
+
+        it("should unpack empty arrays", async function() {
+            const packed = "JXT::data:1:0"
+            const want = {
+                "people": []
+            };
+            
+            const unpacked = await jsonxt.unpack(packed, () => {
+                return ARRAY_TEMPLATES;
+            });
+
+            const got = unpacked
+
+            assert.deepEqual(got, want)
+        })
+
+        it("should unpack null arrays", async function() {
+            const packed = "JXT::data:1:"
+            const want = {
+                
+            };
+            
+            const unpacked = await jsonxt.unpack(packed, () => {
+                return ARRAY_TEMPLATES;
+            });
+            
+            const got = unpacked
+
+            assert.deepEqual(got, want)
+        })
+    })
+
     describe("edge cases", function() {
         const NAME = "w3vc-1-1"
         const TYPE = "w3vc"


### PR DESCRIPTION
Implementation of the third idea discussed here: https://github.com/Consensas/jsonxt/issues/6 

I didn't make an encoder for arrays because these special array encoders need to transform multiple fields. 