### PR TITLE
Adding multi-base encoding support

### DIFF
--- a/javascript/lib/coders/multibase-base36.js
+++ b/javascript/lib/coders/multibase-base36.js
@@ -1,0 +1,106 @@
+/*
+ *  lib/encoders/multibase-base36.js
+ *
+ *  Vitor Pamplona
+ *  PathCheck Foundation
+ *  2021-03-16
+ *
+ *  Copyright (2013-2021) Consensas
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+"use strict"
+
+const _util = require("../_util")
+const NAME = "multibase-base36"
+
+const multibase = require('multibase')
+
+const textDecoder = new TextDecoder();
+
+const decodeText = (bytes) => textDecoder.decode(bytes)
+
+/**
+ *  TESTING ONLY (for now, anyway)
+ */
+/* istanbul ignore next */
+exports.encode = (rule, value) => {
+    const jsonxt = require("..")
+
+    if (_util.isNull(value)) {
+        return rule.NULL || jsonxt.ENCODE.NULL
+    } else if (_util.isUndefined(value)) {
+        return rule.UNDEFINED || jsonxt.ENCODE.UNDEFINED
+    } else if (!_util.isString(value)) {
+        throw new Error(`${NAME}: expected value to be string (got "${value}")`)
+    }
+
+    // decodes a base, adds the base representation to the first char of the decoded array, encode in base36 and then remove the Base36 marker
+    const _encoder = mBase => {
+        let bytes = multibase.decode(mBase);
+        let enc_bytes = new Uint8Array(bytes.length+1);
+        enc_bytes.set(new  Uint8Array([mBase.charCodeAt(0)]), 0);
+        enc_bytes.set(bytes, 1);
+        return decodeText(multibase.encode('base36upper', enc_bytes)).substring(1)
+    }
+
+    if (value === "") {
+        return rule.EMPTY_STRING || jsonxt.ENCODE.EMPTY_STRING
+    } else if (value.startsWith(jsonxt.ENCODE.ESCAPE)) {
+        return jsonxt.ENCODE.ESCAPE + jsonxt.ENCODE.ESCAPE + _encoder(`${value}`)
+    } else {
+        return _encoder(`${value}`)
+    }
+}
+
+/**
+ */
+/* istanbul ignore next */
+exports.decode = (rule, value) => {
+    const jsonxt = require("..")
+
+    if ((value === rule.NULL) || (value === jsonxt.ENCODE.NULL)) {
+        return null
+    } else if ((value === rule.UNDEFINED) || (value === jsonxt.ENCODE.UNDEFINED)) {
+        return undefined
+    } else if ((value === rule.EMPTY_STRING) || (value === jsonxt.ENCODE.EMPTY_STRING)) {
+        return ""
+    }
+
+    // adds Base36 identifier, decodes Base36, removes first byte and turns into the representation to encode in the original form. 
+    const _decoder = base36 => {
+        let decodedArray = multibase.decode("K"+base36);
+        let encodeTo = decodedArray[0];
+        let base = decodedArray.slice(1);
+        return decodeText(multibase.encode(String.fromCharCode(encodeTo), base));
+    }
+
+    if (value.startsWith(jsonxt.ENCODE.ESCAPE)) {
+        if (value[1] === jsonxt.ENCODE.ESCAPE) {
+            value = value.substring(2)
+            value = "$" + _decoder(`${value}`)
+        } else {
+            value = value.substring(1)
+            value = "$" + _decoder(`${value}`)
+        }
+    } else {
+        value = _decoder(`${value}`)
+    }
+
+    return value
+}
+
+exports.schema = {
+    type: "multibase-base36",
+}

--- a/javascript/lib/index.js
+++ b/javascript/lib/index.js
@@ -43,6 +43,7 @@ module.exports = Object.assign(
             "hex-base32": require("./coders/hex-base32").encode,
             "ascii-base32": require("./coders/ascii-base32").encode,
             "base64-base32": require("./coders/base64-base32").encode,
+            "multibase-base36": require("./coders/multibase-base36").encode,
             "string": require("./coders/string").encode,
         },
         decoders: {
@@ -58,6 +59,7 @@ module.exports = Object.assign(
             "hex-base32": require("./coders/hex-base32").decode,
             "ascii-base32": require("./coders/ascii-base32").decode,
             "base64-base32": require("./coders/base64-base32").decode,
+            "multibase-base36": require("./coders/multibase-base36").decode,
             "string": require("./coders/string").decode,
         },
     }

--- a/javascript/lib/unpack.js
+++ b/javascript/lib/unpack.js
@@ -102,6 +102,7 @@ const remove_term_map = async (array) => {
 const unpack_payload = async (payload, template, templates) => {
     // Rebuilds sequences of null fields that were mapped into ' ' + index. 
     // Reverts * and $ as field separators: * -> /* and $ -> /$
+    // TODO: This is UGLY. Need to find a better way to run over all these regex in order.  
     const dup = payload
         .replace(/ G/g, "///////////////////")
         .replace(/ F/g, "//////////////////")

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,5 +1,5 @@
 {
-    "author": "", 
+    "author": "",
     "bugs": {
         "url": "https://github.com/dpjanes/jsonxt/issues"
     }, 
@@ -12,20 +12,22 @@
         "js-yaml": "~4.1.0", 
         "lodash": "~4.17.21", 
         "webpack": "^4.44.1", 
+        "mocha": "^9.0.0",
         "webpack-cli": "~4.7.2"
     }, 
-    "homepage": "https://jsonxt.io", 
-    "license": "Apache-2.0", 
-    "main": "index.js", 
-    "name": "jsonxt", 
+    },
+    "homepage": "https://jsonxt.io",
+    "license": "Apache-2.0",
+    "main": "index.js",
+    "name": "jsonxt",
     "repository": {
         "type": "git", 
         "url": "https://github.com/dpjanes/jsonxt"
     }, 
     "scripts": {
-        "cover": "nyc --reporter=html mocha --recursive", 
-        "test": "mocha --recursive --bail", 
+        "cover": "nyc --reporter=html mocha --recursive",
+        "test": "mocha --recursive --bail",
         "webpack": "webpack --config webpack.config.js"
-    }, 
+    },
     "version": "0.0.16"
 }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,17 +4,17 @@
         "url": "https://github.com/Consensas/jsonxt/issues"
     },
     "dependencies": {
-        "base32url": "~0.0.6", 
-        "base64-js": "~1.5.1"
-    }, 
-    "description": "JSON External Templates", 
+        "base32url": "~0.0.6",
+        "base64-js": "~1.5.1",
+        "multibase": "^4.0.4"
+    },
+    "description": "JSON External Templates",
     "devDependencies": {
-        "js-yaml": "~4.1.0", 
-        "lodash": "~4.17.21", 
-        "webpack": "^4.44.1", 
+        "js-yaml": "~4.1.0",
+        "lodash": "~4.17.21",
         "mocha": "^9.0.0",
+        "webpack": "^4.44.1",
         "webpack-cli": "~4.7.2"
-    }, 
     },
     "homepage": "https://jsonxt.io",
     "license": "Apache-2.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,8 +1,8 @@
 {
     "author": "",
     "bugs": {
-        "url": "https://github.com/dpjanes/jsonxt/issues"
-    }, 
+        "url": "https://github.com/Consensas/jsonxt/issues"
+    },
     "dependencies": {
         "base32url": "~0.0.6", 
         "base64-js": "~1.5.1"
@@ -21,9 +21,9 @@
     "main": "index.js",
     "name": "jsonxt",
     "repository": {
-        "type": "git", 
-        "url": "https://github.com/dpjanes/jsonxt"
-    }, 
+        "type": "git",
+        "url": "https://github.com/Consensas/jsonxt"
+    },
     "scripts": {
         "cover": "nyc --reporter=html mocha --recursive",
         "test": "mocha --recursive --bail",

--- a/javascript/test/coders/multibase-base36.js
+++ b/javascript/test/coders/multibase-base36.js
@@ -1,0 +1,152 @@
+/*
+ *  test/coders/multibase-base36.js
+ *
+ *  Vitor Pamplona
+ *  PathCheck Foundation
+ *  2021-03-30
+ *
+ *  Copyright (2013-2021) Consensas
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+"use strict"
+
+const _ = require("lodash")
+const jsonxt = require("../..")
+
+const fs = require("fs")
+const path = require("path")
+const assert = require("assert")
+
+const _util = require("./../_util")
+
+const WRITE = process.env.WRITE === "1"
+const DUMP = process.env.DUMP === "1"
+
+const TESTCLASS = "multibase-base36";
+
+describe("coders/multibase-base36", function() {
+    before(function() {
+        _util.shims_on()
+    })
+
+    after(function() {
+        _util.shims_off()
+    })
+
+    const rule = { 
+    }
+
+    it("works - zero", function() {
+        const start = ''
+        const got_encoded = jsonxt.encoders[TESTCLASS](rule, start)
+        const got_decoded = jsonxt.decoders[TESTCLASS](rule, got_encoded)
+        const want = "$"
+
+        if (DUMP) {
+            console.log("")
+            console.log("start:", start)
+            console.log("encoded:", got_encoded)
+        }
+
+        assert.strictEqual(got_encoded, want)
+        assert.strictEqual(got_decoded, start)
+    })
+
+    it("works - multibase signature", function() {
+        const start = "z44RDDFBvPHfSLQQC13cggevnts7DFQRUXQg9YfYrNx5m4PAoqR3qFydGwtUsEvQL4WwjRX2Lp2m87H6NKRuaHEKC"
+        const got_encoded = jsonxt.encoders[TESTCLASS](rule, start)
+        const got_decoded = jsonxt.decoders[TESTCLASS](rule, got_encoded)
+        const want = "3UN30D2FI1ZQGHWK7OJFX06V3O1FJ13KOX48Z4GOA370XTC064WBO7T7YCEJY1BBGI23PIEC7CAA3EKQ3UL0TMA3QSG7A8O8RQMF7"
+
+        if (DUMP) {
+            console.log("")
+            console.log("start:", start)
+            console.log("encoded:", got_encoded)
+        }
+
+        assert.strictEqual(got_encoded, want)
+        assert.strictEqual(got_decoded, start)
+    })
+
+    it("works - multibase Key", function() {
+        const start = "z5Q2WLLaD7aJ44s6Aw6qXf1vNor9quCe1ZLhHqc63yhfFF63tbuTgPHgCzXKUbkHAGm8oE9jiQpCPepD88Jgyy7FW"
+        const got_encoded = jsonxt.encoders[TESTCLASS](rule, start)
+        const got_decoded = jsonxt.decoders[TESTCLASS](rule, got_encoded)
+        const want = "3UXQ5XT2QETCC7HXT8T4JDQ33JIGGZSBB4BHT1C1I2TIVKKII2ZJH2PPO2RKZ42HWMSPGPOM3RS6OWA5URVH6821EP5SRRBWDUFSX"
+
+        if (DUMP) {
+            console.log("")
+            console.log("start:", start)
+            console.log("encoded:", got_encoded)
+        }
+
+        assert.strictEqual(got_encoded, want)
+        assert.strictEqual(got_decoded, start)
+    })
+
+    it("works - null", function() {
+        const start = null
+        const got_encoded = jsonxt.encoders[TESTCLASS](rule, start)
+        const got_decoded = jsonxt.decoders[TESTCLASS](rule, got_encoded)
+        const want = "$."
+
+        if (DUMP) {
+            console.log("")
+            console.log("start:", start)
+            console.log("encoded:", got_encoded)
+        }
+
+        assert.strictEqual(got_encoded, want)
+        assert.strictEqual(got_decoded, start)
+    })
+
+    it("works - undefined", function() {
+        const start = undefined
+        const got_encoded = jsonxt.encoders[TESTCLASS](rule, start)
+        const got_decoded = jsonxt.decoders[TESTCLASS](rule, got_encoded)
+        const want = ""
+
+        if (DUMP) {
+            console.log("")
+            console.log("start:", start)
+            console.log("encoded:", got_encoded)
+        }
+
+        assert.strictEqual(got_encoded, want)
+        assert.strictEqual(got_decoded, start)
+    })
+
+    it("expected fail - number", function() {
+        const start = 1
+
+        assert.rejects(async () => {
+            const got_encoded = jsonxt.encoders[TESTCLASS](rule, start)
+        })
+    })
+    it("expected fail - number", function() {
+        const start = 3.14
+
+        assert.rejects(async () => {
+            const got_encoded = jsonxt.encoders[TESTCLASS](rule, start)
+        })
+    })
+    it("expected fail - boolean", function() {
+        const start = true
+
+        assert.rejects(async () => {
+            const got_encoded = jsonxt.encoders[TESTCLASS](rule, start)
+        })
+    })
+})


### PR DESCRIPTION
[Multi-base](https://github.com/multiformats/multibase) is just `<char>`+blob, where `<char>` represents the encoding of the blob. It's being used in the new versions of proof and key hashes. 

Minor: 
- Fixing github URL on package.json
- Adding Mocha back (unsure what happened to it). 